### PR TITLE
bugfix: env won't reinstall if it doesn't exist.

### DIFF
--- a/start_cli.py
+++ b/start_cli.py
@@ -23,6 +23,7 @@ def main():
         install_mgr.setup()
 
     # Activate environment and run main.py
+    install_mgr.check_environment()
     if platform.system().lower() == "windows":
         activate_cmd = f"call {install_mgr.activate_script} {install_mgr.env_name}"
     else:

--- a/start_webui.py
+++ b/start_webui.py
@@ -23,6 +23,7 @@ def main():
         install_mgr.setup()
 
     # Activate environment and run server
+    install_mgr.check_environment()
     if platform.system().lower() == "windows":
         activate_cmd = f"call {install_mgr.activate_script} {install_mgr.env_name}"
     else:

--- a/utils/install_utils.py
+++ b/utils/install_utils.py
@@ -115,13 +115,8 @@ class InstallationManager:
         else:
             subprocess.run(["bash", "-c", pip_install_cmd], check=True)
 
-    def setup(self):
-        """Run complete setup process"""
-        if not self.conda_dir.exists():
-            installer = self.download_miniconda()
-            self.install_miniconda(installer)
-
-        # Create environment if it doesn't exist
+    def check_environment(self):
+        """Check if 'open-llm-vtuber' environment exists and install if not"""
         result = subprocess.run(
             [str(self.conda_executable), "env", "list"],
             capture_output=True,
@@ -132,3 +127,12 @@ class InstallationManager:
             self.create_environment()
             self.install_conda_dependencies()
             self.install_pip_dependencies()
+
+    def setup(self):
+        """Run complete setup process"""
+        if not self.conda_dir.exists():
+            installer = self.download_miniconda()
+            self.install_miniconda(installer)
+
+        # Create environment if it doesn't exist
+        self.check_environment()


### PR DESCRIPTION
Bug:
With miniconda correctly installed but failed in the installation of 'open-llm-vtuber' venv, then try to start project by running start_webui.py, the bug will occur.
Fix:
Just add a check before activate venv.
